### PR TITLE
GitHub issues yönetimi eklendi

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Yazılım geliştirme ile ilgili özenle seçilmiş Türkçe kaynaklar listesi.
 - :movie_camera: [Git ve GitHub Kullanımı](https://www.youtube.com/watch?v=rWG70T7fePg&list=PLPrHLaayVkhnNstGIzQcxxnj6VYvsHBHy) - [Barış Aslan](https://www.youtube.com/c/Bar%C4%B1%C5%9FAslan)
 - [Git Püf Noktaları](http://git.gelistiriciyiz.biz) - [Vigo](https://twitter.com/vigobronx)
 - [git init](https://medium.com/@mustafazahidefe/git-notlar%C4%B1-2-git-i%CC%87nit-f54292fbf631) - Mustafa Zahid Efe
+- [Github Görev Yönetimi (Issues) ve Organizasyon](https://medium.com/@noteCe/5-github-g%C3%B6rev-y%C3%B6netimi-i%CC%87ssues-ve-organizasyon-1277ef74b409)
 
 
 ### Go


### PR DESCRIPTION
GitHub hakkında iyi makaleler görüyorum fakat hepsini faydalı linkler veya git altına atmak ne kadar doğru olur. "GitHub" adında bir başlık daha açsak nasıl olur?

> edit: Github yazan yerler -> GitHub' yapıldı.