### PR TITLE
OpenSSL CA Kılavuzu eklendi.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Yazılım geliştirme ile ilgili özenle seçilmiş Türkçe kaynaklar listesi.
 - [Geleceği Yazanlar - Node.js Eğitimi(ileri seviye)](https://gelecegiyazanlar.turkcell.com.tr/konu/web-programlama/egitim/401)
 - :movie_camera: [Node.JS Eğitim Videoları](https://www.youtube.com/playlist?list=PLh9ECzBB8tJOkzZUbc9CngE-6XeyDFeSY) - [Şadi Evren Şeker](http://sadievrenseker.com)
 
+### OpenSSL
+- [OpenSSL CA Kılavuzu](https://github.com/zekiunal/openssl-certificate-authority-guide)
 
 ### OSX
 - [OSX Püf Noktaları](http://osx.gelistiriciyiz.biz) - [OSX Tips](https://twitter.com/osx_tips_tr)


### PR DESCRIPTION
Bu kılavuz, OpenSSL komut satırı araçlarını kullanarak kendi sertifika yetkilinizi (CA) nasıl kurup kullanacağınızı gösterir.